### PR TITLE
separate new_by_filename and import expectations

### DIFF
--- a/spec/mp3_importer_spec.rb
+++ b/spec/mp3_importer_spec.rb
@@ -30,15 +30,13 @@ describe "MP3Importer" do
     end
   end
 
-  describe '#import' do 
+  describe '#import' do
     it 'imports the files into the library by creating songs from a filename' do
-      Artist.class_variable_set("@@all",[])
       test_music_path = "./spec/fixtures/mp3s"
       music_importer = MP3Importer.new(test_music_path)
-      music_importer.import
 
-      expect(Artist.all.size).to eq(3)
-      expect(Artist.all.first.songs.empty? && Artist.all.last.songs.empty?).to eq(false)
+      expect(Song).to receive(:new_by_filename).at_least(4).times
+      music_importer.import
     end
   end
 end

--- a/spec/song_spec.rb
+++ b/spec/song_spec.rb
@@ -1,4 +1,4 @@
-describe 'Song' do 
+describe 'Song' do
   let(:song) {Song.new('Man in the Mirror')}
   let(:file_name) {'Michael Jackson - Black or White - pop.mp3'}
 
@@ -23,11 +23,18 @@ describe 'Song' do
     end
   end
 
-  describe '.new_by_filename' do 
-    it 'creates a new instance of a song from the file that\'s passed in' do 
+  describe '.new_by_filename' do
+    it 'creates a new instance of a song from the file that\'s passed' do
       new_instance = Song.new_by_filename(file_name)
       expect(new_instance.name).to eq('Black or White')
+    end
+
+    it 'associates new song instance with the artist from the filename' do
+      Artist.class_variable_set("@@all",[])
+      new_instance = Song.new_by_filename(file_name)
       expect(new_instance.artist.name).to eq('Michael Jackson')
+      expect(Artist.all.size).to eq(1)
+      expect(Artist.all.first.songs.empty?).to eq(false)
     end
   end
 end


### PR DESCRIPTION
@Alicekb 
Students often are confused by the error messages pertaining to the import method. The last couple of expectations are really related to the new_by_filename method, not the import method. I cleaned up the tests a little bit to make this clearer. 