### PR TITLE
replace back ticks, describe not showing in command line

### DIFF
--- a/spec/artist_spec.rb
+++ b/spec/artist_spec.rb
@@ -29,7 +29,7 @@ describe 'Artist' do
     end
   end
 
-  describe `#songs` do
+  describe '#songs' do
     it 'lists all songs that belong to this artist' do
       artist = Artist.new('Michael Jackson')
       dirty_diana = Song.new("Dirty Diana")


### PR DESCRIPTION
with back ticks on describe '#songs' do line in tests we get the following
```
  .all
    returns all existing Artist instances (FAILED - 3)
  
    lists all songs that belong to this artist (FAILED - 4)
  #add_song
    keeps track of an artist's songs (FAILED - 5)
```
this makes it look like the description for for #songs is really part of .all

with single quotes for describe '#songs' do we get:
```
  .all
    returns all existing Artist instances (FAILED - 3)
  #songs
    lists all songs that belong to this artist (FAILED - 4)
  #add_song
    keeps track of an artist's songs (FAILED - 5)
```
@drakeltheryuujin