### PR TITLE
Fix #songs test to add song instances to @song

### DIFF
--- a/spec/artist_spec.rb
+++ b/spec/artist_spec.rb
@@ -29,18 +29,6 @@ describe 'Artist' do
     end
   end
 
-  describe '#songs' do
-    it 'lists all songs that belong to this artist' do
-      artist = Artist.new('Michael Jackson')
-      dirty_diana = Song.new("Dirty Diana")
-      billie_jean = Song.new("Billie Jean")
-      piano_man = Song.new("Piano Man")
-      dirty_diana.artist = artist
-      billie_jean.artist = artist
-      expect(artist.songs).to eq([dirty_diana, billie_jean])
-    end
-  end
-
   describe '#add_song' do
     it 'keeps track of an artist\'s songs' do
       artist = Artist.new('Michael Jackson')
@@ -53,7 +41,17 @@ describe 'Artist' do
     end
   end
 
-
+  describe '#songs' do
+    it 'lists all songs that belong to this artist' do
+      artist = Artist.new('Michael Jackson')
+      dirty_diana = Song.new("Dirty Diana")
+      billie_jean = Song.new("Billie Jean")
+      piano_man = Song.new("Piano Man")
+      artist.add_song(dirty_diana)
+      artist.add_song(billie_jean)
+      expect(artist.songs).to eq([dirty_diana, billie_jean])
+    end
+  end
 
   describe '.find_or_create_by_name' do
     it 'always returns an Artist instance' do


### PR DESCRIPTION
The #songs spec is testing for the @songs array to show Song instances within an Artist's collection. However, the test does not add instances yet expects instances to be present. The failure is confusing students who have otherwise functional code.

This commit fixes the code to add instances via the #add_song method and also reorders the #songs test to come after the #add_song test for easier comprehension.